### PR TITLE
chore: update readme for sample nuon actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 ## Nuon Actions
 
 Sample actions for working with Nuon managed apps.
+
+### Kube
+
+Actions for working with Kubernetes.
+
+### Nuon
+
+Actions for working with the nuon api.
+
+### Outputs
+
+Sample Actions for writing outputs.
+
+### AWS
+
+Sample Actions for working with AWS.

--- a/nuon/cli
+++ b/nuon/cli
@@ -20,4 +20,4 @@ if [ -z "${NUON_ORG_ID}" ]; then
 fi
 
 echo >&2 "executing"
-nuon "$@"
+nuon --json "$@"

--- a/nuon/cli
+++ b/nuon/cli
@@ -4,11 +4,6 @@ set -e
 set -o pipefail
 set -u
 
-echo "running healthcheck"
-echo " endpoint: $ENDPOINT"
-echo "  expects: $EXPECTED_STATUS_CODE"
-
-
 echo >&2 "installing nuon"
 echo "y" | /bin/bash -c "$(curl -fsSL https://nuon-artifacts.s3.us-west-2.amazonaws.com/cli/install.sh)"
 

--- a/nuon/exec
+++ b/nuon/exec
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+
+set -e
+set -o pipefail
+set -u
+
+echo "running healthcheck"
+echo " endpoint: $ENDPOINT"
+echo "  expects: $EXPECTED_STATUS_CODE"
+
+
+echo >&2 "installing nuon"
+echo "y" | /bin/bash -c "$(curl -fsSL https://nuon-artifacts.s3.us-west-2.amazonaws.com/cli/install.sh)"
+
+if [ -z "${NUON_API_TOKEN}" ]; then
+  echo >&2 "NUON_API_TOKEN must be set in the environment"
+fi
+
+if [ -z "${NUON_API_URL}" ]; then
+  echo >&2 "NUON_API_URL must be set in the environment"
+fi
+
+if [ -z "${NUON_ORG_ID}" ]; then
+  echo >&2 "NUON_ORG_ID must be set in the environment"
+fi
+
+echo >&2 "executing"
+nuon "$@"


### PR DESCRIPTION
This is an example of using `nuon actions` to work with the `nuon` api directly.
